### PR TITLE
refactor(psygometry): rename "test" to "quiz"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # psygometry
 
-A Golang and HTMX project for a nice, AI-powered [psychometry test](https://en.wikipedia.org/wiki/Psychometric_Entrance_Test) studying experience.
+A Golang and HTMX project for a nice, AI-powered [psychometry quiz](https://en.wikipedia.org/wiki/Psychometric_Entrance_Test) studying experience.

--- a/cmd/psygometry/domain.go
+++ b/cmd/psygometry/domain.go
@@ -18,7 +18,7 @@ type Section struct {
 	Questions []Question
 }
 
-type PsychometryTest struct {
+type PsychometryQuiz struct {
 	EssaySection string
 	VSections    [2]Section
 	QSections    [2]Section
@@ -32,20 +32,20 @@ type PsychometryAnswers struct {
 	ESections    [2][]int
 }
 
-func newPsychometryAnswers(test PsychometryTest) PsychometryAnswers {
+func newPsychometryAnswers(quiz PsychometryQuiz) PsychometryAnswers {
 	answers := PsychometryAnswers{
 		EssaySection: "",
 		VSections: [2][]int{
-			make([]int, len(test.VSections[0].Questions)),
-			make([]int, len(test.VSections[1].Questions)),
+			make([]int, len(quiz.VSections[0].Questions)),
+			make([]int, len(quiz.VSections[1].Questions)),
 		},
 		QSections: [2][]int{
-			make([]int, len(test.QSections[0].Questions)),
-			make([]int, len(test.QSections[1].Questions)),
+			make([]int, len(quiz.QSections[0].Questions)),
+			make([]int, len(quiz.QSections[1].Questions)),
 		},
 		ESections: [2][]int{
-			make([]int, len(test.ESections[0].Questions)),
-			make([]int, len(test.ESections[1].Questions)),
+			make([]int, len(quiz.ESections[0].Questions)),
+			make([]int, len(quiz.ESections[1].Questions)),
 		},
 	}
 
@@ -75,8 +75,8 @@ var (
 	InvalidIndex  = errors.New("invalid index")
 )
 
-func ParsePsychometryAnswers(form url.Values, test PsychometryTest) (*PsychometryAnswers, error) {
-	answers := newPsychometryAnswers(test)
+func ParsePsychometryAnswers(form url.Values, quiz PsychometryQuiz) (*PsychometryAnswers, error) {
+	answers := newPsychometryAnswers(quiz)
 
 	r := regexp.MustCompile("[\\][.]+")
 
@@ -150,8 +150,8 @@ func ParsePsychometryAnswers(form url.Values, test PsychometryTest) (*Psychometr
 	return &answers, nil
 }
 
-func generateFakeData() PsychometryTest {
-	test := PsychometryTest{
+func generateFakeData() PsychometryQuiz {
+	quiz := PsychometryQuiz{
 		EssaySection: "Please write an essay on the importance of storytelling in modern cinema.",
 		VSections: [2]Section{
 			{
@@ -250,5 +250,5 @@ func generateFakeData() PsychometryTest {
 			},
 		},
 	}
-	return test
+	return quiz
 }

--- a/cmd/psygometry/parse_test.go
+++ b/cmd/psygometry/parse_test.go
@@ -18,8 +18,8 @@ func makeSectionArray(size int) [2]Section {
 	return [2]Section{makeSection(size), makeSection(size)}
 }
 
-func (PsychometryTest) Generate(rand *rand.Rand, size int) reflect.Value {
-	pt := PsychometryTest{
+func (PsychometryQuiz) Generate(rand *rand.Rand, size int) reflect.Value {
+	pt := PsychometryQuiz{
 		EssaySection: "",
 		VSections:    makeSectionArray(size),
 		QSections:    makeSectionArray(size),
@@ -30,11 +30,11 @@ func (PsychometryTest) Generate(rand *rand.Rand, size int) reflect.Value {
 
 // Test: parsing an answer form with only an essay is done successfully
 func TestParsePsychometryAnswers_success(t *testing.T) {
-	success := func(test PsychometryTest, essay string) bool {
+	success := func(quiz PsychometryQuiz, essay string) bool {
 		form := url.Values{}
 		form.Add("EssaySection", essay)
 
-		a, err := ParsePsychometryAnswers(form, test)
+		a, err := ParsePsychometryAnswers(form, quiz)
 		return err == nil && a.EssaySection == essay
 	}
 
@@ -69,8 +69,8 @@ func (invalidKeyValues) Generate(rand *rand.Rand, size int) reflect.Value {
 }
 
 func TestParsePsychometryAnswers_invalidKey(t *testing.T) {
-	invalidKey := func(test PsychometryTest, form invalidKeyValues) bool {
-		_, err := ParsePsychometryAnswers(url.Values(form), test)
+	invalidKey := func(quiz PsychometryQuiz, form invalidKeyValues) bool {
+		_, err := ParsePsychometryAnswers(url.Values(form), quiz)
 		return err == InvalidKey
 	}
 
@@ -94,8 +94,8 @@ func (missingIndexValues) Generate(rand *rand.Rand, size int) reflect.Value {
 }
 
 func TestParsePsychometryAnswers_missingIndex(t *testing.T) {
-	missingIndex := func(test PsychometryTest, form missingIndexValues) bool {
-		_, err := ParsePsychometryAnswers(url.Values(form), test)
+	missingIndex := func(quiz PsychometryQuiz, form missingIndexValues) bool {
+		_, err := ParsePsychometryAnswers(url.Values(form), quiz)
 		return err == MissingIndex
 	}
 
@@ -119,8 +119,8 @@ func (deformedIndexValues) Generate(rand *rand.Rand, size int) reflect.Value {
 }
 
 func TestParsePsychometryAnswers_deformedIndex(t *testing.T) {
-	deformedIndex := func(test PsychometryTest, form deformedIndexValues) bool {
-		_, err := ParsePsychometryAnswers(url.Values(form), test)
+	deformedIndex := func(quiz PsychometryQuiz, form deformedIndexValues) bool {
+		_, err := ParsePsychometryAnswers(url.Values(form), quiz)
 		return err == DeformedIndex
 	}
 
@@ -149,8 +149,8 @@ func (invalidIndexValues) Generate(rand *rand.Rand, size int) reflect.Value {
 }
 
 func TestParsePsychometryAnswers_invalidIndex(t *testing.T) {
-	invalidIndex := func(test PsychometryTest, form invalidIndexValues) bool {
-		_, err := ParsePsychometryAnswers(url.Values(form), test)
+	invalidIndex := func(quiz PsychometryQuiz, form invalidIndexValues) bool {
+		_, err := ParsePsychometryAnswers(url.Values(form), quiz)
 		return err == InvalidIndex
 	}
 

--- a/docs/todos.md
+++ b/docs/todos.md
@@ -1,11 +1,11 @@
 # Project TODOs
 
 - [x] Create a basic HTMX website
-- [x] Create data structure for test
+- [x] Create data structure for quiz
 - [x] Create fake data
-- [x] Render test data in the client, without sending correct answers
-- [x] Create data structure for test answers
-- [x] Send test answers to server
+- [x] Render quiz data in the client, without sending correct answers
+- [x] Create data structure for quiz answers
+- [x] Send quiz answers to server
 - [x] Parse answers from request
     - [x] Test
 - [ ] Calculate static scores
@@ -15,5 +15,5 @@
 - [ ] Properly paginate between sections
 - [ ] Add time limits
 - [ ] Connect to a database
-- [ ] Fill database with existing/example psychometry tests
+- [ ] Fill database with existing/example psychometry quizzes
 - [ ] Optional: allow users to upload images and recognize text within them


### PR DESCRIPTION
Rename things to consistently call it a "psychometry quiz" and not a "psychometry test".
