### PR TITLE
feat(psygometry): calculate static scores

### DIFF
--- a/cmd/psygometry/parse_test.go
+++ b/cmd/psygometry/parse_test.go
@@ -19,13 +19,13 @@ func makeSectionArray(size int) [2]Section {
 }
 
 func (PsychometryQuiz) Generate(rand *rand.Rand, size int) reflect.Value {
-	pt := PsychometryQuiz{
+	quiz := PsychometryQuiz{
 		EssaySection: "",
 		VSections:    makeSectionArray(size),
 		QSections:    makeSectionArray(size),
 		ESections:    makeSectionArray(size),
 	}
-	return reflect.ValueOf(pt)
+	return reflect.ValueOf(quiz)
 }
 
 // Test: parsing an answer form with only an essay is done successfully

--- a/cmd/psygometry/psygometry.go
+++ b/cmd/psygometry/psygometry.go
@@ -44,12 +44,14 @@ func main() {
 			return err
 		}
 
-		fmt.Print("----------\n")
 		answers, err := ParsePsychometryAnswers(req.Form, fakeData)
 		if err != nil {
 			return err
 		}
-		json.NewEncoder(os.Stdout).Encode(answers)
+		summary := CalculateScoreSummary(fakeData, *answers)
+
+		fmt.Print("----------\n")
+		json.NewEncoder(os.Stdout).Encode(summary)
 		fmt.Print("----------\n")
 
 		return c.NoContent(http.StatusCreated)

--- a/cmd/psygometry/score.go
+++ b/cmd/psygometry/score.go
@@ -1,0 +1,97 @@
+package main
+
+func RawCategoryScore(quizSections [2]Section, answerSections [2][]int) int {
+	score := 0
+
+	for i, section := range quizSections {
+		for j, question := range section.Questions {
+			option := answerSections[i][j]
+			if option == question.CorrectOption {
+				score += 1
+			}
+		}
+	}
+
+	return score
+}
+
+func UniformCategoryScore(quizSections [2]Section, rawScore int) int {
+	totalQuestions := len(quizSections[0].Questions) + len(quizSections[1].Questions)
+	percent := rawScore * 100 / totalQuestions
+	return percent + 50
+}
+
+var measurementRanges = map[int][2]int{
+	51:  {221, 248},
+	56:  {249, 276},
+	61:  {277, 304},
+	66:  {305, 333},
+	71:  {334, 361},
+	76:  {362, 389},
+	81:  {390, 418},
+	86:  {419, 446},
+	91:  {447, 474},
+	96:  {475, 503},
+	101: {504, 531},
+	106: {532, 559},
+	111: {560, 587},
+	116: {588, 616},
+	121: {617, 644},
+	126: {645, 672},
+	131: {673, 701},
+	136: {702, 729},
+	141: {730, 761},
+	145: {762, 795},
+}
+
+func GeneralMeasurementRange(score int) [2]int {
+	if score <= 50 {
+		return [2]int{200, 200}
+	}
+
+	if score >= 150 {
+		return [2]int{800, 800}
+	}
+
+	return measurementRanges[((score-1)/5)*5]
+}
+
+type ScoreSummary struct {
+	VRaw int
+	QRaw int
+	ERaw int
+
+	VUniform int
+	QUniform int
+	EUniform int
+
+	MultiCategoryUniform int
+	LanguageFocusUniform int
+	MathFocusUniform     int
+
+	MultiCategoryGeneral [2]int
+	LanguageFocusGeneral [2]int
+	MathFocusGeneral     [2]int
+}
+
+func CalculateScoreSummary(quiz PsychometryQuiz, answers PsychometryAnswers) ScoreSummary {
+	summary := ScoreSummary{}
+
+	summary.VRaw = RawCategoryScore(quiz.VSections, answers.VSections)
+	summary.QRaw = RawCategoryScore(quiz.QSections, answers.QSections)
+	summary.ERaw = RawCategoryScore(quiz.ESections, answers.ESections)
+
+	summary.VUniform = UniformCategoryScore(quiz.VSections, summary.VRaw)
+	summary.QUniform = UniformCategoryScore(quiz.QSections, summary.QRaw)
+	summary.EUniform = UniformCategoryScore(quiz.ESections, summary.ERaw)
+
+	summary.MultiCategoryUniform = (2*summary.VUniform + 2*summary.QUniform + summary.EUniform) / 5
+	summary.LanguageFocusUniform = (3*summary.VUniform + summary.QUniform + summary.EUniform) / 5
+	summary.MathFocusUniform = (3*summary.QUniform + summary.VUniform + summary.EUniform) / 5
+
+	summary.MultiCategoryGeneral = GeneralMeasurementRange(summary.MultiCategoryUniform)
+	summary.LanguageFocusGeneral = GeneralMeasurementRange(summary.LanguageFocusUniform)
+	summary.MathFocusGeneral = GeneralMeasurementRange(summary.MathFocusUniform)
+
+	return summary
+}

--- a/cmd/psygometry/score.go
+++ b/cmd/psygometry/score.go
@@ -1,6 +1,6 @@
 package main
 
-func RawCategoryScore(quizSections [2]Section, answerSections [2][]int) int {
+func rawCategoryScore(quizSections [2]Section, answerSections [2][]int) int {
 	score := 0
 
 	for i, section := range quizSections {
@@ -15,7 +15,7 @@ func RawCategoryScore(quizSections [2]Section, answerSections [2][]int) int {
 	return score
 }
 
-func UniformCategoryScore(quizSections [2]Section, rawScore int) int {
+func uniformCategoryScore(quizSections [2]Section, rawScore int) int {
 	totalQuestions := len(quizSections[0].Questions) + len(quizSections[1].Questions)
 	percent := rawScore * 100 / totalQuestions
 	return percent + 50
@@ -44,7 +44,7 @@ var measurementRanges = map[int][2]int{
 	145: {762, 795},
 }
 
-func GeneralMeasurementRange(score int) [2]int {
+func generalMeasurementRange(score int) [2]int {
 	if score <= 50 {
 		return [2]int{200, 200}
 	}
@@ -77,21 +77,21 @@ type ScoreSummary struct {
 func CalculateScoreSummary(quiz PsychometryQuiz, answers PsychometryAnswers) ScoreSummary {
 	summary := ScoreSummary{}
 
-	summary.VRaw = RawCategoryScore(quiz.VSections, answers.VSections)
-	summary.QRaw = RawCategoryScore(quiz.QSections, answers.QSections)
-	summary.ERaw = RawCategoryScore(quiz.ESections, answers.ESections)
+	summary.VRaw = rawCategoryScore(quiz.VSections, answers.VSections)
+	summary.QRaw = rawCategoryScore(quiz.QSections, answers.QSections)
+	summary.ERaw = rawCategoryScore(quiz.ESections, answers.ESections)
 
-	summary.VUniform = UniformCategoryScore(quiz.VSections, summary.VRaw)
-	summary.QUniform = UniformCategoryScore(quiz.QSections, summary.QRaw)
-	summary.EUniform = UniformCategoryScore(quiz.ESections, summary.ERaw)
+	summary.VUniform = uniformCategoryScore(quiz.VSections, summary.VRaw)
+	summary.QUniform = uniformCategoryScore(quiz.QSections, summary.QRaw)
+	summary.EUniform = uniformCategoryScore(quiz.ESections, summary.ERaw)
 
 	summary.MultiCategoryUniform = (2*summary.VUniform + 2*summary.QUniform + summary.EUniform) / 5
 	summary.LanguageFocusUniform = (3*summary.VUniform + summary.QUniform + summary.EUniform) / 5
 	summary.MathFocusUniform = (3*summary.QUniform + summary.VUniform + summary.EUniform) / 5
 
-	summary.MultiCategoryGeneral = GeneralMeasurementRange(summary.MultiCategoryUniform)
-	summary.LanguageFocusGeneral = GeneralMeasurementRange(summary.LanguageFocusUniform)
-	summary.MathFocusGeneral = GeneralMeasurementRange(summary.MathFocusUniform)
+	summary.MultiCategoryGeneral = generalMeasurementRange(summary.MultiCategoryUniform)
+	summary.LanguageFocusGeneral = generalMeasurementRange(summary.LanguageFocusUniform)
+	summary.MathFocusGeneral = generalMeasurementRange(summary.MathFocusUniform)
 
 	return summary
 }

--- a/cmd/psygometry/score_test.go
+++ b/cmd/psygometry/score_test.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"math/rand"
+	"reflect"
+	"testing"
+	"testing/quick"
+)
+
+type scoreSummaryInput struct {
+	quiz    PsychometryQuiz
+	answers PsychometryAnswers
+}
+
+func makeAnswerSection(size int) []int {
+	return make([]int, size)
+}
+
+func makeAnswerSectionArray(size int) [2][]int {
+	return [2][]int{makeAnswerSection(size), makeAnswerSection(size)}
+}
+
+func (scoreSummaryInput) Generate(rand *rand.Rand, size int) reflect.Value {
+	quiz := PsychometryQuiz{
+		EssaySection: "",
+		VSections:    makeSectionArray(size),
+		QSections:    makeSectionArray(size),
+		ESections:    makeSectionArray(size),
+	}
+	answers := PsychometryAnswers{
+		EssaySection: "",
+		VSections:    makeAnswerSectionArray(size),
+		QSections:    makeAnswerSectionArray(size),
+		ESections:    makeAnswerSectionArray(size),
+	}
+
+	return reflect.ValueOf(scoreSummaryInput{quiz, answers})
+}
+
+func rawOutOfBounds(rawScore int, sections [2]Section) bool {
+	return rawScore < 0 || rawScore > len(sections[0].Questions)+len(sections[1].Questions)
+}
+
+func uniformOutOfBounds(uniformScore int) bool {
+	return uniformScore < 50 || uniformScore > 150
+}
+
+func generalInvalid(generalScore [2]int) bool {
+	outOfBoundsMin := generalScore[0] < 200 || generalScore[0] > 800
+	outOfBoundsMax := generalScore[1] < 200 || generalScore[1] > 800
+	outOfBounds := outOfBoundsMin || outOfBoundsMax
+	invalidRange := generalScore[0] > generalScore[1]
+	return outOfBounds || invalidRange
+}
+
+// Test: calculating a score summary always returns a valid score summary within the proper ranges
+func TestCalculateScoreSummary_valid(t *testing.T) {
+	valid := func(input scoreSummaryInput) bool {
+		scoreSummary := CalculateScoreSummary(input.quiz, input.answers)
+
+		// Ensure the raw scores are never greater than their section sizes or less than 0
+		vRawOutOfBounds := rawOutOfBounds(scoreSummary.VRaw, input.quiz.VSections)
+		qRawOutOfBounds := rawOutOfBounds(scoreSummary.QRaw, input.quiz.QSections)
+		eRawOutOfBounds := rawOutOfBounds(scoreSummary.ERaw, input.quiz.ESections)
+		if vRawOutOfBounds || qRawOutOfBounds || eRawOutOfBounds {
+			return false
+		}
+
+		// Ensure the uniform scores are always between 50 and 150
+		vUniformOutOfBounds := uniformOutOfBounds(scoreSummary.VUniform)
+		qUniformOutOfBounds := uniformOutOfBounds(scoreSummary.QUniform)
+		eUniformOutOfBounds := uniformOutOfBounds(scoreSummary.EUniform)
+		if vUniformOutOfBounds || qUniformOutOfBounds || eUniformOutOfBounds {
+			return false
+		}
+
+		// Ensure the general score range is between 200 and 800,
+		// and that the minimum score is less than or equal to the maximum score
+		multiCategoryInvalid := generalInvalid(scoreSummary.MultiCategoryGeneral)
+		mathFocusInvalid := generalInvalid(scoreSummary.MathFocusGeneral)
+		languageFocusInvalid := generalInvalid(scoreSummary.LanguageFocusGeneral)
+		if multiCategoryInvalid || mathFocusInvalid || languageFocusInvalid {
+			return false
+		}
+
+		return true
+	}
+
+	if err := quick.Check(valid, nil); err != nil {
+		t.Error(err)
+	}
+}

--- a/docs/todos.md
+++ b/docs/todos.md
@@ -7,9 +7,9 @@
 - [x] Create data structure for quiz answers
 - [x] Send quiz answers to server
 - [x] Parse answers from request
-    - [x] Test
-- [ ] Calculate static scores
-    - [ ] Test
+  - [x] Test
+- [x] Calculate static scores
+  - [x] Test
 - [ ] Create basic AI package that grades essays
 - [ ] Respond with grade, or possibly grade-range
 - [ ] Properly paginate between sections


### PR DESCRIPTION
Calculate static test scores, i.e. scores that can be determined without using AI. Also, add property-based-testing to ensure the calculated score is always valid.
